### PR TITLE
Added a little shortcut to ease api discovery	

### DIFF
--- a/celery_api.py
+++ b/celery_api.py
@@ -2,6 +2,15 @@
 """
 Celery API discovery module.
 """
+from celery import Celery
+
+
+def make_api(*args, **kwargs):
+    """
+    Little shortcut for api discovery
+    """
+    celery = Celery(*args, **kwargs)
+    return CeleryApi(celery)
 
 
 class CeleryApi(object):


### PR DESCRIPTION
``` python
from celery import Celery
from celery_api import CeleryApi
celery = Celery(...)
api = CeleryApi(celery)
```

VS

``` python
from celery_api import make_api
api = make_api(...)
```
